### PR TITLE
Check the $path variable for undef

### DIFF
--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -166,7 +166,7 @@ sub find_lib
 
   foreach my $path (@path)
   {
-    next unless -d $path;
+    next unless (defined $path || -d $path);
     my $dh;
     opendir $dh, $path;
     my @maybe = 


### PR DESCRIPTION
Check the $path variable for undef before test the $path is a dir or not. 

In Windows OS + Active Perl, Following code generates the "uninitialized variable" warning,
use strict;
use warnings;
use FFI::Platypus;
use FFI::CheckLib;
use Data::Dumper;

#libffi.dll.a is in C:\perl\site\lib\auto\share\dist\Alien-FFI\lib

#print find_lib(lib=>'msvcrt',libpath=>'c:/');
my $ffi = FFI::Platypus->new;
$ffi->lib(undef); # search libc

This check in fix the warning.